### PR TITLE
FIX: Refactor tax handling for Odoo 18.0 compatibility and update vie…

### DIFF
--- a/l10n_ec_account_edi/data/xsd/xmldsig-core-schema.xsd
+++ b/l10n_ec_account_edi/data/xsd/xmldsig-core-schema.xsd
@@ -1,0 +1,318 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE schema
+  PUBLIC "-//W3C//DTD XMLSchema 200102//EN" "http://www.w3.org/2001/XMLSchema.dtd"
+ [
+   <!ATTLIST schema 
+     xmlns:ds CDATA #FIXED "http://www.w3.org/2000/09/xmldsig#">
+   <!ENTITY dsig 'http://www.w3.org/2000/09/xmldsig#'>
+   <!ENTITY % p ''>
+   <!ENTITY % s ''>
+  ]>
+
+<!-- Schema for XML Signatures
+    http://www.w3.org/2000/09/xmldsig#
+    $Revision: 1.1 $ on $Date: 2002/02/08 20:32:26 $ by $Author: reagle $
+
+    Copyright 2001 The Internet Society and W3C (Massachusetts Institute
+    of Technology, Institut National de Recherche en Informatique et en
+    Automatique, Keio University). All Rights Reserved.
+    http://www.w3.org/Consortium/Legal/
+
+    This document is governed by the W3C Software License [1] as described
+    in the FAQ [2].
+
+    [1] http://www.w3.org/Consortium/Legal/copyright-software-19980720
+    [2] http://www.w3.org/Consortium/Legal/IPR-FAQ-20000620.html#DTD
+-->
+
+
+<schema xmlns="http://www.w3.org/2001/XMLSchema"
+        xmlns:ds="http://www.w3.org/2000/09/xmldsig#"
+        targetNamespace="http://www.w3.org/2000/09/xmldsig#"
+        version="0.1" elementFormDefault="qualified"> 
+
+<!-- Basic Types Defined for Signatures -->
+
+<simpleType name="CryptoBinary">
+  <restriction base="base64Binary">
+  </restriction>
+</simpleType>
+
+<!-- Start Signature -->
+
+<element name="Signature" type="ds:SignatureType"/>
+<complexType name="SignatureType">
+  <sequence> 
+    <element ref="ds:SignedInfo"/> 
+    <element ref="ds:SignatureValue"/> 
+    <element ref="ds:KeyInfo" minOccurs="0"/> 
+    <element ref="ds:Object" minOccurs="0" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/>
+</complexType>
+
+  <element name="SignatureValue" type="ds:SignatureValueType"/> 
+  <complexType name="SignatureValueType">
+    <simpleContent>
+      <extension base="base64Binary">
+        <attribute name="Id" type="ID" use="optional"/>
+      </extension>
+    </simpleContent>
+  </complexType>
+
+<!-- Start SignedInfo -->
+
+<element name="SignedInfo" type="ds:SignedInfoType"/>
+<complexType name="SignedInfoType">
+  <sequence> 
+    <element ref="ds:CanonicalizationMethod"/> 
+    <element ref="ds:SignatureMethod"/> 
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>  
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="CanonicalizationMethod" type="ds:CanonicalizationMethodType"/> 
+  <complexType name="CanonicalizationMethodType" mixed="true">
+    <sequence>
+      <any namespace="##any" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+  <element name="SignatureMethod" type="ds:SignatureMethodType"/>
+  <complexType name="SignatureMethodType" mixed="true">
+    <sequence>
+      <element name="HMACOutputLength" minOccurs="0" type="ds:HMACOutputLengthType"/>
+      <any namespace="##other" minOccurs="0" maxOccurs="unbounded"/>
+      <!-- (0,unbounded) elements from (1,1) external namespace -->
+    </sequence>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- Start Reference -->
+
+<element name="Reference" type="ds:ReferenceType"/>
+<complexType name="ReferenceType">
+  <sequence> 
+    <element ref="ds:Transforms" minOccurs="0"/> 
+    <element ref="ds:DigestMethod"/> 
+    <element ref="ds:DigestValue"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="URI" type="anyURI" use="optional"/> 
+  <attribute name="Type" type="anyURI" use="optional"/> 
+</complexType>
+
+  <element name="Transforms" type="ds:TransformsType"/>
+  <complexType name="TransformsType">
+    <sequence>
+      <element ref="ds:Transform" maxOccurs="unbounded"/>  
+    </sequence>
+  </complexType>
+
+  <element name="Transform" type="ds:TransformType"/>
+  <complexType name="TransformType" mixed="true">
+    <choice minOccurs="0" maxOccurs="unbounded"> 
+      <any namespace="##other" processContents="lax"/>
+      <!-- (1,1) elements from (0,unbounded) namespaces -->
+      <element name="XPath" type="string"/> 
+    </choice>
+    <attribute name="Algorithm" type="anyURI" use="required"/> 
+  </complexType>
+
+<!-- End Reference -->
+
+<element name="DigestMethod" type="ds:DigestMethodType"/>
+<complexType name="DigestMethodType" mixed="true"> 
+  <sequence>
+    <any namespace="##other" processContents="lax" minOccurs="0" maxOccurs="unbounded"/>
+  </sequence>    
+  <attribute name="Algorithm" type="anyURI" use="required"/> 
+</complexType>
+
+<element name="DigestValue" type="ds:DigestValueType"/>
+<simpleType name="DigestValueType">
+  <restriction base="base64Binary"/>
+</simpleType>
+
+<!-- End SignedInfo -->
+
+<!-- Start KeyInfo -->
+
+<element name="KeyInfo" type="ds:KeyInfoType"/> 
+<complexType name="KeyInfoType" mixed="true">
+  <choice maxOccurs="unbounded">     
+    <element ref="ds:KeyName"/> 
+    <element ref="ds:KeyValue"/> 
+    <element ref="ds:RetrievalMethod"/> 
+    <element ref="ds:X509Data"/> 
+    <element ref="ds:PGPData"/> 
+    <element ref="ds:SPKIData"/>
+    <element ref="ds:MgmtData"/>
+    <any processContents="lax" namespace="##other"/>
+    <!-- (1,1) elements from (0,unbounded) namespaces -->
+  </choice>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+  <element name="KeyName" type="string"/>
+  <element name="MgmtData" type="string"/>
+
+  <element name="KeyValue" type="ds:KeyValueType"/> 
+  <complexType name="KeyValueType" mixed="true">
+   <choice>
+     <element ref="ds:DSAKeyValue"/>
+     <element ref="ds:RSAKeyValue"/>
+     <any namespace="##other" processContents="lax"/>
+   </choice>
+  </complexType>
+
+  <element name="RetrievalMethod" type="ds:RetrievalMethodType"/> 
+  <complexType name="RetrievalMethodType">
+    <sequence>
+      <element ref="ds:Transforms" minOccurs="0"/> 
+    </sequence>  
+    <attribute name="URI" type="anyURI"/>
+    <attribute name="Type" type="anyURI" use="optional"/>
+  </complexType>
+
+<!-- Start X509Data -->
+
+<element name="X509Data" type="ds:X509DataType"/> 
+<complexType name="X509DataType">
+  <sequence maxOccurs="unbounded">
+    <choice>
+      <element name="X509IssuerSerial" type="ds:X509IssuerSerialType"/>
+      <element name="X509SKI" type="base64Binary"/>
+      <element name="X509SubjectName" type="string"/>
+      <element name="X509Certificate" type="base64Binary"/>
+      <element name="X509CRL" type="base64Binary"/>
+      <any namespace="##other" processContents="lax"/>
+    </choice>
+  </sequence>
+</complexType>
+
+<complexType name="X509IssuerSerialType"> 
+  <sequence> 
+    <element name="X509IssuerName" type="string"/> 
+    <element name="X509SerialNumber" type="integer"/> 
+  </sequence>
+</complexType>
+
+<!-- End X509Data -->
+
+<!-- Begin PGPData -->
+
+<element name="PGPData" type="ds:PGPDataType"/> 
+<complexType name="PGPDataType"> 
+  <choice>
+    <sequence>
+      <element name="PGPKeyID" type="base64Binary"/> 
+      <element name="PGPKeyPacket" type="base64Binary" minOccurs="0"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+    <sequence>
+      <element name="PGPKeyPacket" type="base64Binary"/> 
+      <any namespace="##other" processContents="lax" minOccurs="0"
+       maxOccurs="unbounded"/>
+    </sequence>
+  </choice>
+</complexType>
+
+<!-- End PGPData -->
+
+<!-- Begin SPKIData -->
+
+<element name="SPKIData" type="ds:SPKIDataType"/> 
+<complexType name="SPKIDataType">
+  <sequence maxOccurs="unbounded">
+    <element name="SPKISexp" type="base64Binary"/>
+    <any namespace="##other" processContents="lax" minOccurs="0"/>
+  </sequence>
+</complexType> 
+
+<!-- End SPKIData -->
+
+<!-- End KeyInfo -->
+
+<!-- Start Object (Manifest, SignatureProperty) -->
+
+<element name="Object" type="ds:ObjectType"/> 
+<complexType name="ObjectType" mixed="true">
+  <sequence minOccurs="0" maxOccurs="unbounded">
+    <any namespace="##any" processContents="lax"/>
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+  <attribute name="MimeType" type="string" use="optional"/> <!-- add a grep facet -->
+  <attribute name="Encoding" type="anyURI" use="optional"/> 
+</complexType>
+
+<element name="Manifest" type="ds:ManifestType"/> 
+<complexType name="ManifestType">
+  <sequence>
+    <element ref="ds:Reference" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+<element name="SignatureProperties" type="ds:SignaturePropertiesType"/> 
+<complexType name="SignaturePropertiesType">
+  <sequence>
+    <element ref="ds:SignatureProperty" maxOccurs="unbounded"/> 
+  </sequence>
+  <attribute name="Id" type="ID" use="optional"/> 
+</complexType>
+
+   <element name="SignatureProperty" type="ds:SignaturePropertyType"/> 
+   <complexType name="SignaturePropertyType" mixed="true">
+     <choice maxOccurs="unbounded">
+       <any namespace="##other" processContents="lax"/>
+       <!-- (1,1) elements from (1,unbounded) namespaces -->
+     </choice>
+     <attribute name="Target" type="anyURI" use="required"/> 
+     <attribute name="Id" type="ID" use="optional"/> 
+   </complexType>
+
+<!-- End Object (Manifest, SignatureProperty) -->
+
+<!-- Start Algorithm Parameters -->
+
+<simpleType name="HMACOutputLengthType">
+  <restriction base="integer"/>
+</simpleType>
+
+<!-- Start KeyValue Element-types -->
+
+<element name="DSAKeyValue" type="ds:DSAKeyValueType"/>
+<complexType name="DSAKeyValueType">
+  <sequence>
+    <sequence minOccurs="0">
+      <element name="P" type="ds:CryptoBinary"/>
+      <element name="Q" type="ds:CryptoBinary"/>
+    </sequence>
+    <element name="G" type="ds:CryptoBinary" minOccurs="0"/>
+    <element name="Y" type="ds:CryptoBinary"/>
+    <element name="J" type="ds:CryptoBinary" minOccurs="0"/>
+    <sequence minOccurs="0">
+      <element name="Seed" type="ds:CryptoBinary"/>
+      <element name="PgenCounter" type="ds:CryptoBinary"/>
+    </sequence>
+  </sequence>
+</complexType>
+
+<element name="RSAKeyValue" type="ds:RSAKeyValueType"/>
+<complexType name="RSAKeyValueType">
+  <sequence>
+    <element name="Modulus" type="ds:CryptoBinary"/> 
+    <element name="Exponent" type="ds:CryptoBinary"/> 
+  </sequence>
+</complexType> 
+
+<!-- End KeyValue Element-types -->
+
+<!-- End Signature -->
+
+</schema>

--- a/l10n_ec_account_edi/models/account_edi_document.py
+++ b/l10n_ec_account_edi/models/account_edi_document.py
@@ -108,9 +108,28 @@ class AccountEdiDocument(models.Model):
     def l10n_ec_header_get_total_with_taxes(self, taxes_data):
         self.ensure_one()
         res = []
-        for tax_data in taxes_data.get("tax_details", {}).values():
-            tax_vals = self._l10n_ec_prepare_tax_vals_edi(tax_data)
-            res.append(tax_vals)
+        
+        # En Odoo 18.0, usar la nueva estructura de datos de _prepare_edi_tax_details
+        tax_details = taxes_data.get("tax_details", {})
+        
+        # Iterar sobre todos los grupos de impuestos 
+        for grouping_key, values in tax_details.items():
+            # Si el grouping_key es un impuesto (objeto account.tax)
+            if hasattr(grouping_key, 'tax_group_id') and hasattr(grouping_key, 'l10n_ec_xml_fe_code'):
+                tax_data = {
+                    "tax": grouping_key,
+                    "base_amount_currency": values.get("base_amount_currency", 0.0),
+                    "tax_amount_currency": values.get("tax_amount_currency", 0.0),
+                }
+                tax_vals = self._l10n_ec_prepare_tax_vals_edi(tax_data)
+                res.append(tax_vals)
+            
+            # Si hay group_tax_details, procesarlos
+            elif "group_tax_details" in values:
+                for tax_data in values["group_tax_details"]:
+                    tax_vals = self._l10n_ec_prepare_tax_vals_edi(tax_data)
+                    res.append(tax_vals)
+        
         return res
 
     def _l10n_ec_get_environment(self):

--- a/l10n_ec_account_edi/models/account_move.py
+++ b/l10n_ec_account_edi/models/account_move.py
@@ -264,7 +264,7 @@ class AccountMove(models.Model):
                 .ids
             )
             return (
-                tax_values["tax_repartition_line"].tax_id.tax_group_id.id
+                tax_values["tax"].tax_group_id.id
                 not in withhold_group_ids
             )
 

--- a/l10n_ec_account_edi/models/account_move_line.py
+++ b/l10n_ec_account_edi/models/account_move_line.py
@@ -72,15 +72,57 @@ class AccountMoveLine(models.Model):
     def _l10n_ec_get_invoice_edi_taxes(self, taxes_data):
         tax_values = []
         EdiDocument = self.env["account.edi.document"]
-        for tax_data in taxes_data.get("tax_details", {}).values():
-            tax_values.append(EdiDocument._l10n_ec_prepare_tax_vals_edi(tax_data))
+        
+        if not taxes_data:
+            return tax_values
+            
+        # En Odoo 18.0, usar la nueva estructura de datos
+        tax_details = taxes_data.get("tax_details", {})
+        
+        # Iterar sobre todos los grupos de impuestos 
+        for grouping_key, values in tax_details.items():
+            # Si el grouping_key es un impuesto (objeto account.tax)
+            if hasattr(grouping_key, 'tax_group_id') and hasattr(grouping_key, 'l10n_ec_xml_fe_code'):
+                tax_data = {
+                    "tax": grouping_key,
+                    "base_amount_currency": values.get("base_amount_currency", 0.0),
+                    "tax_amount_currency": values.get("tax_amount_currency", 0.0),
+                }
+                tax_values.append(EdiDocument._l10n_ec_prepare_tax_vals_edi(tax_data))
+            
+            # Si hay group_tax_details, procesarlos
+            elif "group_tax_details" in values:
+                for tax_data in values["group_tax_details"]:
+                    tax_values.append(EdiDocument._l10n_ec_prepare_tax_vals_edi(tax_data))
+        
         return tax_values
 
     def _l10n_ec_get_credit_note_edi_taxes(self, taxes_data):
         tax_values = []
         EdiDocument = self.env["account.edi.document"]
-        for tax_data in taxes_data.get("tax_details", {}).values():
-            tax_values.append(EdiDocument._l10n_ec_prepare_tax_vals_edi(tax_data))
+        
+        if not taxes_data:
+            return tax_values
+            
+        # En Odoo 18.0, usar la nueva estructura de datos
+        tax_details = taxes_data.get("tax_details", {})
+        
+        # Iterar sobre todos los grupos de impuestos 
+        for grouping_key, values in tax_details.items():
+            # Si el grouping_key es un impuesto (objeto account.tax)
+            if hasattr(grouping_key, 'tax_group_id') and hasattr(grouping_key, 'l10n_ec_xml_fe_code'):
+                tax_data = {
+                    "tax": grouping_key,
+                    "base_amount_currency": values.get("base_amount_currency", 0.0),
+                    "tax_amount_currency": values.get("tax_amount_currency", 0.0),
+                }
+                tax_values.append(EdiDocument._l10n_ec_prepare_tax_vals_edi(tax_data))
+            
+            # Si hay group_tax_details, procesarlos
+            elif "group_tax_details" in values:
+                for tax_data in values["group_tax_details"]:
+                    tax_values.append(EdiDocument._l10n_ec_prepare_tax_vals_edi(tax_data))
+        
         return tax_values
 
     def l10n_ec_get_debit_note_edi_data(self, taxes_data):

--- a/l10n_ec_account_edi/views/account_edi_document_view.xml
+++ b/l10n_ec_account_edi/views/account_edi_document_view.xml
@@ -78,7 +78,7 @@
         <field name="name">XML Electronic Documents</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">account.edi.document</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="view_id" ref="account_edi_document_view_tree" />
     </record>
     <menuitem

--- a/l10n_ec_account_edi/views/account_move_view.xml
+++ b/l10n_ec_account_edi/views/account_move_view.xml
@@ -80,10 +80,10 @@
                         name="l10n_ec_additional_information_move_ids"
                         readonly="state != 'draft'"
                     >
-                        <tree editable="bottom">
+                        <list editable="bottom">
                             <field name="name" />
                             <!-- <field name="description" /> -->
-                        </tree>
+                        </list>
                         <form>
                             <group>
                                 <field name="name" />
@@ -131,7 +131,7 @@
     >
         <field name="name">Liquidation of Purchase</field>
         <field name="res_model">account.move</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">list,kanban,form</field>
         <field name="view_id" ref="account.view_invoice_tree" />
         <field name="search_view_id" ref="account.view_account_invoice_filter" />
         <field
@@ -188,7 +188,7 @@
     <record id="action_move_debit_note_type" model="ir.actions.act_window">
         <field name="name">Debit Notes</field>
         <field name="res_model">account.move</field>
-        <field name="view_mode">tree,kanban,form</field>
+        <field name="view_mode">list,kanban,form</field>
         <field name="view_id" ref="account.view_invoice_tree" />
         <field name="search_view_id" ref="account.view_account_invoice_filter" />
         <field

--- a/l10n_ec_account_edi/views/sri_key_type_view.xml
+++ b/l10n_ec_account_edi/views/sri_key_type_view.xml
@@ -110,7 +110,7 @@
         <field name="name">Electronic Signature Certs</field>
         <field name="type">ir.actions.act_window</field>
         <field name="res_model">sri.key.type</field>
-        <field name="view_mode">tree,form</field>
+        <field name="view_mode">list,form</field>
         <field name="view_id" ref="sri_key_type_tree_view" />
         <field name="search_view_id" ref="sri_key_type_search_view" />
     </record>


### PR DESCRIPTION
This pull request introduces significant updates to the Ecuadorian localization module for electronic invoicing in Odoo. The changes include the addition of an XML schema for digital signatures, updates to tax handling logic to align with Odoo 18.0's new data structure, and adjustments to views for consistency in user interface terminology.

### Key Changes

#### 1. Addition of XML Schema for Digital Signatures
* Added a new file, `l10n_ec_account_edi/data/xsd/xmldsig-core-schema.xsd`, containing the XML schema for digital signatures. This schema defines the structure for XML signatures, including elements like `Signature`, `SignedInfo`, `KeyInfo`, and `Object`. It is critical for supporting electronic signature functionality in compliance with XMLDSIG standards.

#### 2. Updates to Tax Handling Logic
* Updated `l10n_ec_header_get_total_with_taxes` in `account_edi_document.py` to iterate over the new `tax_details` structure and process both individual taxes and grouped tax details.
* Updated `filter_withholding_taxes` in `account_move.py` to use `tax` instead of `tax_repartition_line` for determining tax group IDs.
* Refactored `_l10n_ec_get_invoice_edi_taxes` and `_l10n_ec_get_credit_note_edi_taxes` in `account_move_line.py` to handle the new `tax_details` structure and process both individual taxes and grouped tax details.

#### 3. User Interface Improvements
* Replaced `tree` view mode with `list` view mode in multiple XML view definitions for consistency and improved terminology:
  - `account_edi_document_view.xml` for "XML Electronic Documents".
  - `account_move_view.xml` for additional information, purchase liquidation, and debit notes. [[1]](diffhunk://#diff-8b6e9ba0cfd3bba72975dd9370140c8a8f33454b0770d9fd4f59fb1b43ea29a7L83-R86) [[2]](diffhunk://#diff-8b6e9ba0cfd3bba72975dd9370140c8a8f33454b0770d9fd4f59fb1b43ea29a7L134-R134) [[3]](diffhunk://#diff-8b6e9ba0cfd3bba72975dd9370140c8a8f33454b0770d9fd4f59fb1b43ea29a7L191-R191)
  - `sri_key_type_view.xml` for electronic signature certificates.